### PR TITLE
Turn off autocorrect attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
     </div>
     <label for="search">🔎 </label>
     <input id="exp_rafsi" type="checkbox" checked style="display: none" />
-    <input autocomplete="off" id="search" placeholder="loading..." disabled />
+    <input autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" id="search" placeholder="loading..." disabled />
     <span id="lujvo_result"></span>
     <dl id="results"></dl>
   </div>


### PR DESCRIPTION
Disable autocapitalize, autocorrect, and spellcheck. These features make it difficult to enter lojban text on some operating systems (especially for mobile devices).