### PR TITLE
Fix "obsolete" formatting

### DIFF
--- a/main.js
+++ b/main.js
@@ -155,14 +155,14 @@ window.addEventListener("DOMContentLoaded", () => {
         lemmaLink.href = "javascript:void(0)";
         lemmaLink.onclick = () => doSearch(lemma);
         lemmaLink.appendChild(document.createTextNode(lemma));
+        if (obsolete) {
+          lemmaLink.className = "obsolete";
+        }
         dt.appendChild(lemmaLink);
         if (extra) {
           const i = document.createElement("i");
           i.appendChild(document.createTextNode(extra));
           dt.appendChild(i);
-        }
-        if (obsolete) {
-          dt.className = "obsolete";
         }
         if (typeof type === "string") {
           const a = document.createElement("a");


### PR DESCRIPTION
Turning the lemma in links broke the line-through formatting for obsolete words. Moving the class from the <dt> to the <a> fixes this.