### PR TITLE
Replace U+2019 with apostrophe in searches

### DIFF
--- a/main.js
+++ b/main.js
@@ -69,7 +69,8 @@ window.addEventListener("DOMContentLoaded", () => {
       return;
     }
     window.history.replaceState(null, null, "?" + lang + "#" + trimmed);
-    const natural = trimmed.replace(/[^\s\p{L}\d']/gu, "").toLowerCase();
+    const noU2019 = trimmed.replaceAll("’", "'");
+    const natural = noU2019.replace(/[^\s\p{L}\d']/gu, "").toLowerCase();
     const apostrophized = natural.replaceAll("h", "'");
     const words = natural.split(/\s+/);
     const specialPatterns = { ja: natural, en: `\\b${natural}e?s?\\b` };


### PR DESCRIPTION
I see U+2019 in lojban text on Discord occasionally, so it seems worth making this substitution in case people are copying and pasting.